### PR TITLE
Removing query config that depends on triggering model

### DIFF
--- a/lib/sqlalchemy_bulk_lazy_loader.py
+++ b/lib/sqlalchemy_bulk_lazy_loader.py
@@ -113,7 +113,6 @@ class BulkLazyLoader(LazyLoader):
         raise UnsupportedRelationError(error_msg)
 
     def _validate_relation(self):
-        
         criterion, param_keys = self._simple_lazy_clause
         if self.parent_property.secondary is None:
             # for relationship without a secondary join criterion should look like: "COL = :param"
@@ -155,17 +154,8 @@ class BulkLazyLoader(LazyLoader):
 
         q = q._with_invoke_all_eagers(False)
 
-        pending = not state.key
-
-        # don't autoflush on pending
-        if pending or passive & attributes.NO_AUTOFLUSH:
+        if passive & attributes.NO_AUTOFLUSH:
             q = q.autoflush(False)
-
-        if state.load_path:
-            q = q._with_current_path(state.load_path[self.parent_property])
-
-        if state.load_options:
-            q = q._conditional_options(*state.load_options)
 
         if self.parent_property.order_by:
             q = q.order_by(*util.to_list(self.parent_property.order_by))


### PR DESCRIPTION
Suggested by @zzzeek here: https://groups.google.com/d/msg/sqlalchemy/pdtZIwt5RPE/MQzYGalnAAAJ

This PR removes loading config that depends on the specific model whose lazy load is triggering the bulk load. This is because there are many models whose lazy relations are being loaded at once besides the original model which triggered the load, so it doesn't make sense to apply settings from one model to all the models being loaded.

Initially this logic was left in after copy/pasting from the SQLAlchemy LazyLoader as I didn't fully understand what the logic was doing or what the implications of deleting it were.