### PR TITLE
The library adjusted to work with SQLAlchemy 1.4.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ sqlnet.log
 /test.py
 /.cache/
 *.sw[o,p]
+.idea
+.eggs

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,8 @@
-# TAKEN FROM SQLALCHEMY
+# TAKEN FROM SQLALCHEMY v1.4.25
+# https://github.com/sqlalchemy/sqlalchemy/blob/rel_1_4_25/setup.cfg
 
 [tool:pytest]
-addopts= --tb native -v -r fxX --maxfail=25
+addopts= --tb native -v -r fxX --maxfail=25 -p no:warnings -p no:logging
 python_files=test/*test_*.py
 
 [sqla_testing]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 # To use a consistent encoding
 from codecs import open
 from os import path
@@ -11,7 +11,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='SQLAlchemy-bulk-lazy-loader',
-    version='0.9.9',
+    version='0.10.0',
     description='A Bulk Lazy Loader for Sqlalchemy that solves the n + 1 loading problem',
     long_description=long_description,
     url='https://github.com/operator/sqlalchemy_bulk_lazy_loader',
@@ -25,9 +25,9 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
     ],
-    tests_require=['pytest >= 2.5.2', 'mock', 'pytest-xdist'],
+    tests_require=['pytest >= 6.2.3', 'mock', 'pytest-xdist'],
     keywords='sqlalchemy orm lazyload joinedload subqueryload',
     py_modules=['sqlalchemy_bulk_lazy_loader'],
     package_dir={'': 'lib'},
-    install_requires=['SQLAlchemy>=1.0'],
+    install_requires=["SQLAlchemy~=1.4"],
 )

--- a/test/_fixtures.py
+++ b/test/_fixtures.py
@@ -1,24 +1,19 @@
-from sqlalchemy import MetaData, Integer, String, ForeignKey, Text
-from sqlalchemy import util, desc
-from sqlalchemy.testing.schema import Table
-from sqlalchemy.testing.schema import Column
-from sqlalchemy.orm import attributes, mapper, relationship, backref, configure_mappers, create_session
+from sqlalchemy import ForeignKey, Integer, String, Text, desc
+from sqlalchemy.orm import backref, configure_mappers, mapper, relationship
 from sqlalchemy.testing import fixtures
-from sqlalchemy.ext.associationproxy import association_proxy
+from sqlalchemy.testing.schema import Column, Table
 
 __all__ = ()
 
 
 class FixtureTest(fixtures.MappedTest):
-    """A MappedTest pre-configured with a common set of fixtures.
+    """A MappedTest pre-configured with a common set of fixtures."""
 
-    """
-
-    run_define_tables = 'once'
-    run_setup_classes = 'once'
-    run_setup_mappers = 'each'
-    run_inserts = 'each'
-    run_deletes = 'each'
+    run_define_tables = "once"
+    run_setup_classes = "once"
+    run_setup_mappers = "each"
+    run_inserts = "each"
+    run_deletes = "each"
 
     @classmethod
     def setup_classes(cls):
@@ -37,7 +32,6 @@ class FixtureTest(fixtures.MappedTest):
         class Thing(Base):
             pass
 
-
     @classmethod
     def setup_mappers(cls):
         User, users = cls.classes.User, cls.tables.users
@@ -45,106 +39,131 @@ class FixtureTest(fixtures.MappedTest):
         Address, addresses = cls.classes.Address, cls.tables.addresses
         Thing, things = cls.classes.Thing, cls.tables.things
 
-        mapper(User, users, properties={
-            'addresses': relationship(
-                Address,
-                backref=backref('user', lazy="bulk"),
-                lazy="bulk",
-                order_by=[desc(addresses.c.email_address)]
-            ),
-            'children': relationship(User, backref=backref('parent', remote_side=[users.c.id], lazy="bulk"), lazy="bulk"),
-            'user_info': relationship(UserInfo, lazy="bulk", backref=backref('user', lazy="bulk"), uselist=False),
-            'things': relationship(Thing, secondary=cls.tables.user_to_things, lazy="bulk"),
-        })
+        mapper(
+            User,
+            users,
+            properties={
+                "addresses": relationship(
+                    Address,
+                    backref=backref("user", lazy="bulk"),
+                    lazy="bulk",
+                    order_by=[desc(addresses.c.email_address)],
+                ),
+                "children": relationship(
+                    User,
+                    backref=backref("parent", remote_side=[users.c.id], lazy="bulk"),
+                    lazy="bulk",
+                ),
+                "user_info": relationship(
+                    UserInfo,
+                    lazy="bulk",
+                    backref=backref("user", lazy="bulk"),
+                    uselist=False,
+                ),
+                "things": relationship(
+                    Thing, secondary=cls.tables.user_to_things, lazy="bulk"
+                ),
+            },
+        )
         mapper(Address, addresses)
         mapper(UserInfo, user_infos)
-        mapper(Thing, things, properties={
-            'users': relationship(User, secondary=cls.tables.user_to_things, lazy="bulk"),
-        })
+        mapper(
+            Thing,
+            things,
+            properties={
+                "users": relationship(
+                    User,
+                    secondary=cls.tables.user_to_things,
+                    lazy="bulk",
+                    overlaps="things",
+                ),
+            },
+        )
 
         configure_mappers()
 
     @classmethod
     def define_tables(cls, metadata):
-        Table('users', metadata,
-              Column('id', Integer, primary_key=True,
-                     test_needs_autoincrement=True),
-              Column('name', String(30), nullable=False),
-              Column('parent_id', None, ForeignKey('users.id')),
-              test_needs_acid=True,
-              test_needs_fk=True)
+        Table(
+            "users",
+            metadata,
+            Column("id", Integer, primary_key=True, test_needs_autoincrement=True),
+            Column("name", String(30), nullable=False),
+            Column("parent_id", None, ForeignKey("users.id")),
+            test_needs_acid=True,
+            test_needs_fk=True,
+        )
 
-        Table('user_infos', metadata,
-              Column('id', Integer, primary_key=True,
-                     test_needs_autoincrement=True),
-              Column('details', Text),
-              Column('user_id', None, ForeignKey('users.id')),
-              test_needs_acid=True,
-              test_needs_fk=True)
+        Table(
+            "user_infos",
+            metadata,
+            Column("id", Integer, primary_key=True, test_needs_autoincrement=True),
+            Column("details", Text),
+            Column("user_id", None, ForeignKey("users.id")),
+            test_needs_acid=True,
+            test_needs_fk=True,
+        )
 
-        Table('addresses', metadata,
-              Column('id', Integer, primary_key=True,
-                     test_needs_autoincrement=True),
-              Column('user_id', None, ForeignKey('users.id')),
-              Column('email_address', String(50), nullable=False),
-              test_needs_acid=True,
-              test_needs_fk=True)
+        Table(
+            "addresses",
+            metadata,
+            Column("id", Integer, primary_key=True, test_needs_autoincrement=True),
+            Column("user_id", None, ForeignKey("users.id")),
+            Column("email_address", String(50), nullable=False),
+            test_needs_acid=True,
+            test_needs_fk=True,
+        )
 
-        Table('things', metadata,
-              Column('id', Integer, primary_key=True,
-                     test_needs_autoincrement=True),
-              Column('name', String(30), nullable=False),
-              test_needs_acid=True,
-              test_needs_fk=True)
+        Table(
+            "things",
+            metadata,
+            Column("id", Integer, primary_key=True, test_needs_autoincrement=True),
+            Column("name", String(30), nullable=False),
+            test_needs_acid=True,
+            test_needs_fk=True,
+        )
 
-        Table('user_to_things', metadata,
-              Column('user_id', None, ForeignKey('users.id')),
-              Column('thing_id', None, ForeignKey('things.id')),
-              test_needs_acid=True,
-              test_needs_fk=True)
-
+        Table(
+            "user_to_things",
+            metadata,
+            Column("user_id", None, ForeignKey("users.id")),
+            Column("thing_id", None, ForeignKey("things.id")),
+            test_needs_acid=True,
+            test_needs_fk=True,
+        )
 
     @classmethod
     def fixtures(cls):
-        return dict(
-            users=(
-                ('id', 'name', 'parent_id'),
-                (7, 'jack', None),
-                (8, 'jack jr', 7),
-                (9, 'fred', 7),
-                (10, 'jack jr jr', 8),
+        return {
+            "users": (
+                ("id", "name", "parent_id"),
+                (7, "jack", None),
+                (8, "jack jr", 7),
+                (9, "fred", 7),
+                (10, "jack jr jr", 8),
             ),
-
-            user_infos=(
-                ('id', 'user_id', 'details'),
-                (1, 7, 'is cool'),
-                (2, 8, 'is not cool'),
-                (3, 10, 'is moderately cool'),
+            "user_infos": (
+                ("id", "user_id", "details"),
+                (1, 7, "is cool"),
+                (2, 8, "is not cool"),
+                (3, 10, "is moderately cool"),
             ),
-
-            addresses=(
-                ('id', 'user_id', 'email_address'),
+            "addresses": (
+                ("id", "user_id", "email_address"),
                 (1, 7, "jack@bean.com"),
                 (2, 8, "jackjr@wood.com"),
                 (3, 8, "jackjr@bettyboop.com"),
                 (4, 8, "jackjr@lala.com"),
-                (5, 9, "fred@fred.com")
+                (5, 9, "fred@fred.com"),
             ),
-
-            things=(
-                ('id', 'name'),
-                (1, 'dog'),
-                (2, 'lamp'),
-                (3, 'chair'),
-            ),
-
-            user_to_things=(
-                ('user_id', 'thing_id'),
+            "things": (("id", "name"), (1, "dog"), (2, "lamp"), (3, "chair")),
+            "user_to_things": (
+                ("user_id", "thing_id"),
                 (7, 1),
-                (8, 1), # include a duplicate intentionally
                 (8, 1),
+                (8, 1),  # include a duplicate intentionally
                 (10, 2),
                 (9, 2),
                 (10, 3),
             ),
-        )
+        }

--- a/test/test_bulk_lazy_loader.py
+++ b/test/test_bulk_lazy_loader.py
@@ -1,41 +1,42 @@
-from sqlalchemy.orm import attributes, create_session, mapper, relationship, configure_mappers
-from sqlalchemy import  Integer, ForeignKey, ForeignKeyConstraint
-from sqlalchemy import event, and_
+from sqlalchemy import ForeignKey, ForeignKeyConstraint, Integer, and_, event
 from sqlalchemy.engine import Engine
+from sqlalchemy.orm import attributes, configure_mappers, mapper, relationship
 from sqlalchemy.testing import fixtures
-from sqlalchemy.testing.schema import Table, Column
-from test import _fixtures
+from sqlalchemy.testing.fixtures import fixture_session
+from sqlalchemy.testing.schema import Column, Table
 
 from lib.sqlalchemy_bulk_lazy_loader import UnsupportedRelationError
+from test import _fixtures
+
 
 class LazyLoadTest(_fixtures.FixtureTest):
     def record_query(self, conn, cursor, statement, parameters, context, executemany):
-        self.queries.append({
-            'statement': statement,
-            'parameters': parameters,
-        })
+        self.queries.append(
+            {
+                "statement": statement,
+                "parameters": parameters,
+            }
+        )
 
     def setup(self):
-        super().setup()
         self.queries = []
-        event.listen(Engine, 'before_cursor_execute', self.record_query)
+        event.listen(Engine, "before_cursor_execute", self.record_query)
 
     def teardown(self):
-        super().teardown()
-        event.remove(Engine, 'before_cursor_execute', self.record_query)
+        event.remove(Engine, "before_cursor_execute", self.record_query)
 
     def test_load_one_to_one(self):
         User = self.classes.User
         UserInfo = self.classes.UserInfo
-        session = create_session()
 
+        session = fixture_session()
         users = session.query(User).order_by(self.tables.users.c.id.asc()).all()
         self.queries = []
 
         # make sure no relations are loaded
         for user in users:
             model_dict = attributes.instance_dict(user)
-            assert 'user_info' not in model_dict
+            assert "user_info" not in model_dict
 
         # trigger a lazy load on the first user
         users[0].user_info
@@ -49,10 +50,15 @@ class LazyLoadTest(_fixtures.FixtureTest):
         user3_dict = attributes.instance_dict(users[2])
         user4_dict = attributes.instance_dict(users[3])
 
-        assert UserInfo(id=1, details='is cool', user_id=7) == user1_dict['user_info']
-        assert UserInfo(id=2, details='is not cool', user_id=8) == user2_dict['user_info']
-        assert None == user3_dict['user_info']
-        assert UserInfo(id=3, details='is moderately cool', user_id=10) == user4_dict['user_info']
+        assert UserInfo(id=1, details="is cool", user_id=7) == user1_dict["user_info"]
+        assert (
+                UserInfo(id=2, details="is not cool", user_id=8) == user2_dict["user_info"]
+        )
+        assert user3_dict["user_info"] is None
+        assert (
+                UserInfo(id=3, details="is moderately cool", user_id=10)
+                == user4_dict["user_info"]
+        )
 
         # backrefs should also not trigger loading
         assert users[0].user_info.user == users[0]
@@ -65,18 +71,18 @@ class LazyLoadTest(_fixtures.FixtureTest):
     def test_only_loads_relations_on_unpopulated_models(self):
         User = self.classes.User
         Address = self.classes.Address
-        session = create_session()
+        session = fixture_session()
 
         users = session.query(User).order_by(self.tables.users.c.id.asc()).all()
         address = session.query(Address).filter(self.tables.addresses.c.id == 1).first()
         # pre-load the address for the first user
-        attributes.set_committed_value(users[0], 'addresses', [address])
+        attributes.set_committed_value(users[0], "addresses", [address])
         self.queries = []
 
         # make sure no relations are loaded
         for user in users[1:]:
             model_dict = attributes.instance_dict(user)
-            assert 'addresses' not in model_dict
+            assert "addresses" not in model_dict
 
         # trigger a lazy load
         users[1].addresses
@@ -84,12 +90,12 @@ class LazyLoadTest(_fixtures.FixtureTest):
         # only 1 query should have been generated to load all the child relationships
         assert len(self.queries) == 1
         unpopulated_user_ids = [user.id for user in users[1:]]
-        assert self.queries[0]['parameters'] == tuple(unpopulated_user_ids)
+        assert self.queries[0]["parameters"] == tuple(unpopulated_user_ids)
 
     def test_load_one_to_many(self):
         User = self.classes.User
         Address = self.classes.Address
-        session = create_session()
+        session = fixture_session()
 
         users = session.query(User).order_by(self.tables.users.c.id.asc()).all()
         self.queries = []
@@ -97,7 +103,7 @@ class LazyLoadTest(_fixtures.FixtureTest):
         # make sure no relations are loaded
         for user in users:
             model_dict = attributes.instance_dict(user)
-            assert 'addresses' not in model_dict
+            assert "addresses" not in model_dict
 
         # trigger a lazy load on the first user
         users[0].addresses
@@ -112,17 +118,17 @@ class LazyLoadTest(_fixtures.FixtureTest):
         user4_dict = attributes.instance_dict(users[3])
 
         assert [
-            Address(id=1, email_address='jack@bean.com', user_id=7),
-        ] == user1_dict['addresses']
-        assert [ # order is by email_address DESC
-            Address(id=2, email_address='jackjr@wood.com', user_id=8),
-            Address(id=4, email_address='jackjr@lala.com', user_id=8),
-            Address(id=3, email_address='jackjr@bettyboop.com', user_id=8),
-        ] == user2_dict['addresses']
+                   Address(id=1, email_address="jack@bean.com", user_id=7),
+               ] == user1_dict["addresses"]
+        assert [  # order is by email_address DESC
+                   Address(id=2, email_address="jackjr@wood.com", user_id=8),
+                   Address(id=4, email_address="jackjr@lala.com", user_id=8),
+                   Address(id=3, email_address="jackjr@bettyboop.com", user_id=8),
+               ] == user2_dict["addresses"]
         assert [
-            Address(id=5, email_address='fred@fred.com', user_id=9),
-        ] == user3_dict['addresses']
-        assert [] == user4_dict['addresses']
+                   Address(id=5, email_address="fred@fred.com", user_id=9),
+               ] == user3_dict["addresses"]
+        assert [] == user4_dict["addresses"]
 
         # backrefs should also not trigger loading
         for address in users[0].addresses:
@@ -138,15 +144,17 @@ class LazyLoadTest(_fixtures.FixtureTest):
     def test_load_many_to_one(self):
         User = self.classes.User
         Address = self.classes.Address
-        session = create_session()
+        session = fixture_session()
 
-        addresses = session.query(Address).order_by(self.tables.addresses.c.id.asc()).all()
+        addresses = (
+            session.query(Address).order_by(self.tables.addresses.c.id.asc()).all()
+        )
         self.queries = []
 
         # make sure no relations are loaded
         for address in addresses:
             model_dict = attributes.instance_dict(address)
-            assert 'user' not in model_dict
+            assert "user" not in model_dict
 
         # trigger a lazy load on the first user
         addresses[0].user
@@ -161,22 +169,22 @@ class LazyLoadTest(_fixtures.FixtureTest):
         address4_dict = attributes.instance_dict(addresses[3])
         address5_dict = attributes.instance_dict(addresses[4])
 
-        assert User(id=7, name='jack', parent_id=None) == address1_dict['user']
-        assert User(id=8, name='jack jr', parent_id=7) == address2_dict['user']
-        assert User(id=8, name='jack jr', parent_id=7) == address3_dict['user']
-        assert User(id=8, name='jack jr', parent_id=7) == address4_dict['user']
-        assert User(id=9, name='fred', parent_id=7) == address5_dict['user']
+        assert User(id=7, name="jack", parent_id=None) == address1_dict["user"]
+        assert User(id=8, name="jack jr", parent_id=7) == address2_dict["user"]
+        assert User(id=8, name="jack jr", parent_id=7) == address3_dict["user"]
+        assert User(id=8, name="jack jr", parent_id=7) == address4_dict["user"]
+        assert User(id=9, name="fred", parent_id=7) == address5_dict["user"]
 
         # no new queries should have been generated
         assert len(self.queries) == 0
 
     def test_load_one_to_many_self_refencing(self):
         User = self.classes.User
-        session = create_session()
+        session = fixture_session()
 
         users = (
             session.query(User)
-                .filter(self.tables.users.c.id.in_([7,8]))
+                .filter(self.tables.users.c.id.in_([7, 8]))
                 .order_by(self.tables.users.c.id.asc())
                 .all()
         )
@@ -185,7 +193,7 @@ class LazyLoadTest(_fixtures.FixtureTest):
         # make sure no relations are loaded
         for user in users:
             model_dict = attributes.instance_dict(user)
-            assert 'children' not in model_dict
+            assert "children" not in model_dict
 
         # trigger a lazy load on the first user
         users[0].children
@@ -198,12 +206,12 @@ class LazyLoadTest(_fixtures.FixtureTest):
         user2_dict = attributes.instance_dict(users[1])
 
         assert [
-            User(id=8, name='jack jr', parent_id=7),
-            User(id=9, name='fred', parent_id=7),
-        ] == user1_dict['children']
+                   User(id=8, name="jack jr", parent_id=7),
+                   User(id=9, name="fred", parent_id=7),
+               ] == user1_dict["children"]
         assert [
-            User(id=10, name='jack jr jr', parent_id=8),
-        ] == user2_dict['children']
+                   User(id=10, name="jack jr jr", parent_id=8),
+               ] == user2_dict["children"]
 
         # backrefs should also not trigger loading
         for child in users[0].children:
@@ -214,10 +222,9 @@ class LazyLoadTest(_fixtures.FixtureTest):
         # no new queries should have been generated
         assert len(self.queries) == 0
 
-
     def test_load_many_to_one_self_refencing(self):
         User = self.classes.User
-        session = create_session()
+        session = fixture_session()
 
         users = (
             session.query(User)
@@ -230,7 +237,7 @@ class LazyLoadTest(_fixtures.FixtureTest):
         # make sure no relations are loaded
         for user in users:
             model_dict = attributes.instance_dict(user)
-            assert 'parent' not in model_dict
+            assert "parent" not in model_dict
 
         # trigger a lazy load on the first user
         users[0].parent
@@ -243,9 +250,9 @@ class LazyLoadTest(_fixtures.FixtureTest):
         user2_dict = attributes.instance_dict(users[1])
         user3_dict = attributes.instance_dict(users[2])
 
-        assert User(id=7, name='jack', parent_id=None) == user1_dict['parent']
-        assert User(id=7, name='jack', parent_id=None) == user2_dict['parent']
-        assert User(id=8, name='jack jr', parent_id=7) == user3_dict['parent']
+        assert User(id=7, name="jack", parent_id=None) == user1_dict["parent"]
+        assert User(id=7, name="jack", parent_id=None) == user2_dict["parent"]
+        assert User(id=8, name="jack jr", parent_id=7) == user3_dict["parent"]
 
         # no new queries should have been generated
         assert len(self.queries) == 0
@@ -253,7 +260,7 @@ class LazyLoadTest(_fixtures.FixtureTest):
     def test_load_many_to_many(self):
         User = self.classes.User
         Thing = self.classes.Thing
-        session = create_session()
+        session = fixture_session()
 
         users = session.query(User).order_by(self.tables.users.c.id.asc()).all()
         self.queries = []
@@ -261,7 +268,7 @@ class LazyLoadTest(_fixtures.FixtureTest):
         # make sure no relations are loaded
         for user in users:
             model_dict = attributes.instance_dict(user)
-            assert 'things' not in model_dict
+            assert "things" not in model_dict
 
         # trigger a lazy load on the first user
         users[0].things
@@ -276,53 +283,61 @@ class LazyLoadTest(_fixtures.FixtureTest):
         user4_dict = attributes.instance_dict(users[3])
 
         assert [
-            Thing(id=1, name='dog'),
-        ] == user1_dict['things']
+                   Thing(id=1, name="dog"),
+               ] == user1_dict["things"]
         assert [
-            Thing(id=1, name='dog'),
-        ] == user2_dict['things']
+                   Thing(id=1, name="dog"),
+               ] == user2_dict["things"]
         assert [
-            Thing(id=2, name='lamp'),
-        ] == user3_dict['things']
+                   Thing(id=2, name="lamp"),
+               ] == user3_dict["things"]
         assert [
-            Thing(id=2, name='lamp'),
-            Thing(id=3, name='chair'),
-        ] == user4_dict['things']
+                   Thing(id=2, name="lamp"),
+                   Thing(id=3, name="chair"),
+               ] == user4_dict["things"]
 
         # no new queries should have been generated
         assert len(self.queries) == 0
+
 
 class BulkLazyLoaderValidationTest(fixtures.MappedTest):
     @classmethod
     def define_tables(cls, metadata):
         Table(
-            'multi_pk', metadata,
+            "multi_pk",
+            metadata,
             Column("id1", Integer, primary_key=True),
             Column("id2", Integer, primary_key=True),
         )
 
         Table(
-            "multi_fk", metadata,
+            "multi_fk",
+            metadata,
             Column("id", Integer, primary_key=True),
-            Column('multi_pk_id1', Integer),
-            Column('multi_pk_id2', Integer),
-            ForeignKeyConstraint(['multi_pk_id1', 'multi_pk_id2'], ['multi_pk.id1', 'multi_pk.id2'])
+            Column("multi_pk_id1", Integer),
+            Column("multi_pk_id2", Integer),
+            ForeignKeyConstraint(
+                ["multi_pk_id1", "multi_pk_id2"], ["multi_pk.id1", "multi_pk.id2"]
+            ),
         )
 
         Table(
-            'a', metadata,
+            "a",
+            metadata,
             Column("id", Integer, primary_key=True),
         )
 
         Table(
-            'b', metadata,
+            "b",
+            metadata,
             Column("id", Integer, primary_key=True),
         )
 
         Table(
-            'a_to_b', metadata,
-            Column('a_id', None, ForeignKey('a.id')),
-            Column('b_id', None, ForeignKey('b.id')),
+            "a_to_b",
+            metadata,
+            Column("a_id", None, ForeignKey("a.id")),
+            Column("b_id", None, ForeignKey("b.id")),
         )
 
     @classmethod
@@ -341,55 +356,75 @@ class BulkLazyLoaderValidationTest(fixtures.MappedTest):
 
     def test_multi_foreign_key_relations_are_not_supported(self):
         mapper(self.classes.MultiPk, self.tables.multi_pk)
-        mapper(self.classes.MultiFk, self.tables.multi_fk, properties={
-            'multi_pks': relationship(self.classes.MultiPk, lazy="bulk")
-        })
+        mapper(
+            self.classes.MultiFk,
+            self.tables.multi_fk,
+            properties={"multi_pks": relationship(self.classes.MultiPk, lazy="bulk")},
+        )
         exception = None
         try:
             configure_mappers()
         except UnsupportedRelationError as e:
             exception = e
         assert exception.args[0] == (
-            'BulkLazyLoader MultiFk.multi_pks: '
-            'Only simple relations on 1 primary key and without custom joins are supported'
+            "BulkLazyLoader MultiFk.multi_pks: "
+            "Only simple relations on 1 primary key and without custom joins are supported"
         )
 
-    def test_secondary_joins_with_custom_primary_join_conditions_are_not_supported(self):
+    def test_secondary_joins_with_custom_primary_join_conditions_are_not_supported(
+            self,
+    ):
         mapper(self.classes.A, self.tables.a)
-        mapper(self.classes.B, self.tables.b, properties={
-            'a': relationship(
-                self.classes.A,
-                secondary=self.tables.a_to_b,
-                primaryjoin=and_(self.tables.b.c.id == self.tables.a_to_b.c.b_id, self.tables.b.c.id > 10),
-                lazy="bulk",
-            )
-        })
+        mapper(
+            self.classes.B,
+            self.tables.b,
+            properties={
+                "a": relationship(
+                    self.classes.A,
+                    secondary=self.tables.a_to_b,
+                    primaryjoin=and_(
+                        self.tables.b.c.id == self.tables.a_to_b.c.b_id,
+                        self.tables.b.c.id > 10,
+                        ),
+                    lazy="bulk",
+                )
+            },
+        )
         exception = None
         try:
             configure_mappers()
         except UnsupportedRelationError as e:
             exception = e
         assert exception.args[0] == (
-            'BulkLazyLoader B.a: '
-            'Only simple relations on 1 primary key and without custom joins are supported'
+            "BulkLazyLoader B.a: "
+            "Only simple relations on 1 primary key and without custom joins are supported"
         )
 
-    def test_secondary_joins_with_custom_secondary_join_conditions_are_not_supported(self):
+    def test_secondary_joins_with_custom_secondary_join_conditions_are_not_supported(
+            self,
+    ):
         mapper(self.classes.A, self.tables.a)
-        mapper(self.classes.B, self.tables.b, properties={
-            'a': relationship(
-                self.classes.A,
-                secondary=self.tables.a_to_b,
-                secondaryjoin=and_(self.tables.a.c.id == self.tables.a_to_b.c.a_id, self.tables.a.c.id > 10),
-                lazy="bulk",
-            )
-        })
+        mapper(
+            self.classes.B,
+            self.tables.b,
+            properties={
+                "a": relationship(
+                    self.classes.A,
+                    secondary=self.tables.a_to_b,
+                    secondaryjoin=and_(
+                        self.tables.a.c.id == self.tables.a_to_b.c.a_id,
+                        self.tables.a.c.id > 10,
+                        ),
+                    lazy="bulk",
+                )
+            },
+        )
         exception = None
         try:
             configure_mappers()
         except UnsupportedRelationError as e:
             exception = e
         assert exception.args[0] == (
-            'BulkLazyLoader B.a: '
-            'Only simple relations on 1 primary key and without custom joins are supported'
+            "BulkLazyLoader B.a: "
+            "Only simple relations on 1 primary key and without custom joins are supported"
         )


### PR DESCRIPTION
This PR includes:

Core code of the bulk loader adjustments works with only SQLAlchemy 1.4.x that some ORM strategies are hardcoded in SQLAlchemy 1.4.x that this adjustment can misbehave with older versions,
Library requirements bumped for SQLAlchemy~=1.4 and pytest >= 6.2.3
Additionally, test cases are adjusted to meet new requirements.

(This changes first time created under https://github.com/operator/sqlalchemy_bulk_lazy_loader/pull/6 that is closed)